### PR TITLE
Fetch GitHub data for user pages

### DIFF
--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -2,15 +2,25 @@ import ProfileCard from "@/components/ProfileCard";
 import Heatmap from "@/components/Heatmap";
 import RepoTable from "@/components/RepoTable";
 import RecentCommits from "@/components/RecentCommits";
+import { getContributions, getRecentEvents } from "@/lib/github";
 
-export default async function UserPage({ params }: { params: { username: string } }) {
+export default async function UserPage({
+  params,
+}: {
+  params: { username: string };
+}) {
   const { username } = params;
+  const [calendar, recent] = await Promise.all([
+    getContributions(username),
+    getRecentEvents(username),
+  ]);
+
   return (
     <main className="p-4">
       <ProfileCard username={username} />
-      <Heatmap data={[]} />
-      <RepoTable repos={[]} />
-      <RecentCommits commits={[]} />
+      <Heatmap data={calendar} />
+      <RepoTable repos={recent.repos} />
+      <RecentCommits commits={recent.commits} />
     </main>
   );
 }

--- a/app/api/github/contributions/route.ts
+++ b/app/api/github/contributions/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { contributionsSchema } from "@/lib/validation";
 import { getCache, setCache } from "@/lib/cache";
-import { transformCalendar } from "@/lib/github";
+import { getContributions } from "@/lib/github";
 
 export async function POST(req: NextRequest) {
   const json = await req.json();
@@ -15,7 +15,7 @@ export async function POST(req: NextRequest) {
   if (cached) {
     return NextResponse.json(cached);
   }
-  const data = transformCalendar({ username, from, to });
+  const data = await getContributions(username, from, to);
   setCache(key, data);
   return NextResponse.json(data);
 }

--- a/app/api/github/recent/route.ts
+++ b/app/api/github/recent/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { usernameSchema } from "@/lib/validation";
 import { getCache, setCache } from "@/lib/cache";
-import { transformEvents } from "@/lib/github";
+import { getRecentEvents } from "@/lib/github";
 
 export async function GET(req: NextRequest) {
   const username = req.nextUrl.searchParams.get("username") ?? "";
@@ -14,7 +14,7 @@ export async function GET(req: NextRequest) {
   if (cached) {
     return NextResponse.json(cached);
   }
-  const data = transformEvents([]);
+  const data = await getRecentEvents(username);
   setCache(key, data);
   return NextResponse.json(data);
 }

--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -2,13 +2,71 @@ import { describe, expect, it } from "vitest";
 import { transformCalendar, transformEvents } from "./github";
 
 describe("github transformers", () => {
-  it("transformCalendar returns data", () => {
-    const input = { a: 1 };
-    expect(transformCalendar(input)).toEqual(input);
+  it("transformCalendar flattens calendar", () => {
+    const input = {
+      user: {
+        contributionsCollection: {
+          contributionCalendar: {
+            weeks: [
+              { contributionDays: [{ date: "2024-01-01", contributionCount: 1 }] },
+              { contributionDays: [{ date: "2024-01-02", contributionCount: 0 }] },
+            ],
+          },
+        },
+      },
+    };
+    expect(transformCalendar(input)).toEqual([
+      { date: "2024-01-01", count: 1 },
+      { date: "2024-01-02", count: 0 },
+    ]);
   });
 
-  it("transformEvents returns events", () => {
-    const events = [{ id: 1 }];
-    expect(transformEvents(events)).toEqual(events);
+  it("transformEvents normalizes commits and repos", () => {
+    const events = [
+      {
+        type: "PushEvent",
+        repo: { name: "foo/bar" },
+        created_at: "2024-01-01T00:00:00Z",
+        payload: {
+          commits: [
+            { sha: "a", message: "first" },
+            { sha: "b", message: "second" },
+          ],
+        },
+      },
+      {
+        type: "PushEvent",
+        repo: { name: "foo/baz" },
+        created_at: "2024-01-02T00:00:00Z",
+        payload: { commits: [{ sha: "c", message: "third" }] },
+      },
+      { type: "IssuesEvent" },
+    ];
+    expect(transformEvents(events)).toEqual({
+      commits: [
+        {
+          repo: "foo/bar",
+          message: "first",
+          date: "2024-01-01T00:00:00Z",
+          url: "https://github.com/foo/bar/commit/a",
+        },
+        {
+          repo: "foo/bar",
+          message: "second",
+          date: "2024-01-01T00:00:00Z",
+          url: "https://github.com/foo/bar/commit/b",
+        },
+        {
+          repo: "foo/baz",
+          message: "third",
+          date: "2024-01-02T00:00:00Z",
+          url: "https://github.com/foo/baz/commit/c",
+        },
+      ],
+      repos: [
+        { name: "foo/bar", commits: 2 },
+        { name: "foo/baz", commits: 1 },
+      ],
+    });
   });
 });

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,6 +1,8 @@
 import { Octokit } from "octokit";
 
-export const octokit = new Octokit();
+export const octokit = new Octokit({
+  auth: process.env.GITHUB_TOKEN,
+});
 
 export async function fetchGraphQL(
   query: string,
@@ -9,10 +11,108 @@ export async function fetchGraphQL(
   return octokit.graphql(query, variables);
 }
 
-export function transformCalendar<T>(data: T): T {
-  return data;
+export type CalendarDay = { date: string; count: number };
+
+export async function getContributions(
+  username: string,
+  from?: string,
+  to?: string,
+): Promise<CalendarDay[]> {
+  const query = `
+    query ($username: String!, $from: DateTime, $to: DateTime) {
+      user(login: $username) {
+        contributionsCollection(from: $from, to: $to) {
+          contributionCalendar {
+            weeks {
+              contributionDays {
+                date
+                contributionCount
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+  const result = (await fetchGraphQL(query, {
+    username,
+    from,
+    to,
+  })) as CalendarResponse;
+  return transformCalendar(result);
 }
 
-export function transformEvents<T>(events: T[]): T[] {
-  return events;
+interface CalendarResponse {
+  user?: {
+    contributionsCollection?: {
+      contributionCalendar?: {
+        weeks: { contributionDays: { date: string; contributionCount: number }[] }[];
+      };
+    };
+  };
+}
+
+export function transformCalendar(data: CalendarResponse): CalendarDay[] {
+  const weeks =
+    data.user?.contributionsCollection?.contributionCalendar?.weeks ?? [];
+  const days: CalendarDay[] = [];
+  for (const week of weeks) {
+    for (const day of week.contributionDays) {
+      days.push({ date: day.date, count: day.contributionCount });
+    }
+  }
+  return days;
+}
+
+export interface Commit {
+  repo: string;
+  message: string;
+  date: string;
+  url: string;
+}
+
+export interface RepoStat {
+  name: string;
+  commits: number;
+}
+
+export async function getRecentEvents(
+  username: string,
+): Promise<{ commits: Commit[]; repos: RepoStat[] }> {
+  const { data } = await octokit.request("GET /users/{username}/events", {
+    username,
+    per_page: 100,
+  });
+  return transformEvents(data as GitHubEvent[]);
+}
+
+interface GitHubEvent {
+  type: string;
+  repo: { name: string };
+  created_at: string;
+  payload: { commits?: { sha: string; message: string }[] };
+}
+
+export function transformEvents(
+  events: GitHubEvent[],
+): { commits: Commit[]; repos: RepoStat[] } {
+  const commits: Commit[] = [];
+  const repoMap: Record<string, number> = {};
+  for (const event of events) {
+    if (event.type !== "PushEvent" || !event.payload.commits) continue;
+    for (const commit of event.payload.commits) {
+      commits.push({
+        repo: event.repo.name,
+        message: commit.message,
+        date: event.created_at,
+        url: `https://github.com/${event.repo.name}/commit/${commit.sha}`,
+      });
+      repoMap[event.repo.name] = (repoMap[event.repo.name] || 0) + 1;
+    }
+  }
+  const repos: RepoStat[] = Object.entries(repoMap).map(([name, count]) => ({
+    name,
+    commits: count,
+  }));
+  return { commits: commits.slice(0, 20), repos };
 }


### PR DESCRIPTION
## Summary
- load contributions and recent commit data for `/[username]` pages
- implement GitHub API helpers and cache-enabled API routes
- add tests for calendar and event transforms

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_68ab42240074832e9e758439b1e8639c