### PR TITLE
Restyle UI with brutalist theme

### DIFF
--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -16,7 +16,7 @@ export default async function Page({
     const recent = await getRecentEvents(username);
 
     return (
-      <main className="p-4">
+      <main className="p-4 space-y-4">
         <ProfileCard username={username} />
         <Heatmap data={calendar} />
         <RepoTable repos={recent.repos} />
@@ -28,9 +28,9 @@ export default async function Page({
       const resetTime = error.resetAt?.toLocaleTimeString() || "unknown time";
       return (
         <main className="p-4">
-          <div className="bg-red-50 border border-red-200 p-4 rounded">
-            <h2 className="text-red-800 font-bold">Rate Limit Exceeded</h2>
-            <p className="text-red-700">
+          <div className="border-2 border-black p-4 text-red-600">
+            <h2 className="font-bold">Rate Limit Exceeded</h2>
+            <p>
               GitHub API rate limit exceeded. Please try again after {resetTime}
               .
             </p>
@@ -41,11 +41,9 @@ export default async function Page({
 
     return (
       <main className="p-4">
-        <div className="bg-red-50 border border-red-200 p-4 rounded">
-          <h2 className="text-red-800 font-bold">Error</h2>
-          <p className="text-red-700">
-            Failed to load GitHub data. Please try again later.
-          </p>
+        <div className="border-2 border-black p-4 text-red-600">
+          <h2 className="font-bold">Error</h2>
+          <p>Failed to load GitHub data. Please try again later.</p>
         </div>
       </main>
     );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,7 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import Providers from "@/components/Providers";
 import Header from "@/components/Header";
 import "../styles/globals.css";
-
-const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "GitHub Activity Viewer",
@@ -18,7 +15,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${inter.className} bg-background text-foreground`}>
+      <body className="bg-white text-black font-mono">
         <Providers>
           <Header />
           {children}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -7,8 +7,8 @@ export default function Header() {
   const { data: session, status } = useSession();
 
   return (
-    <header className="border-b p-4 flex justify-between items-center">
-      <Link href="/" className="font-bold text-xl">
+    <header className="border-b-2 border-black p-4 flex justify-between items-center bg-white">
+      <Link href="/" className="font-bold text-2xl">
         GitHub Activity
       </Link>
       <div>
@@ -16,10 +16,10 @@ export default function Header() {
           <span>Loading...</span>
         ) : session?.user ? (
           <div className="flex gap-4 items-center">
-            <span>{session.user.name}</span>
+            <span className="font-bold">{session.user.name}</span>
             <button
               onClick={() => signOut()}
-              className="px-4 py-2 bg-gray-100 rounded"
+              className="border-2 border-black px-4 py-2 bg-white text-black"
             >
               Sign Out
             </button>
@@ -27,7 +27,7 @@ export default function Header() {
         ) : (
           <button
             onClick={() => signIn("github")}
-            className="px-4 py-2 bg-gray-900 text-white rounded"
+            className="border-2 border-black px-4 py-2 bg-black text-white"
           >
             Sign in with GitHub
           </button>

--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -5,7 +5,7 @@ import { ResponsiveContainer } from "recharts";
 export default function Heatmap({ data }: { data: unknown[] }) {
   void data;
   return (
-    <div className="w-full h-40 bg-gray-100 flex items-center justify-center">
+    <div className="w-full h-40 border-2 border-black flex items-center justify-center bg-white">
       <ResponsiveContainer>
         <div>Heatmap</div>
       </ResponsiveContainer>

--- a/components/ProfileCard.tsx
+++ b/components/ProfileCard.tsx
@@ -4,7 +4,7 @@ interface Props {
 
 export default function ProfileCard({ username }: Props) {
   return (
-    <div className="border p-4 mb-4">
+    <div className="border-2 border-black p-4 mb-4 bg-white">
       <p className="font-bold">@{username}</p>
     </div>
   );

--- a/components/RecentCommits.tsx
+++ b/components/RecentCommits.tsx
@@ -7,15 +7,17 @@ interface Commit {
 
 export default function RecentCommits({ commits }: { commits: Commit[] }) {
   return (
-    <ul>
+    <ul className="border-2 border-black">
       {commits.map((c, i) => (
-        <li key={i} className="w-full flex items-center justify-between">
+        <li
+          key={i}
+          className="flex items-center justify-between p-2 border-b border-black last:border-b-0"
+        >
           <div>
             <a href={c.url} className="underline">
               {c.message}
             </a>
           </div>
-
           <div>
             ({c.repo} - {c.date})
           </div>

--- a/components/RepoTable.tsx
+++ b/components/RepoTable.tsx
@@ -5,16 +5,16 @@ interface Repo {
 
 export default function RepoTable({ repos }: { repos: Repo[] }) {
   return (
-    <table className="min-w-full border mb-1">
+    <table className="min-w-full border-2 border-black mb-4">
       <thead>
         <tr>
-          <th className="text-left px-2">Repo</th>
-          <th className="text-left px-2">Commits</th>
+          <th className="text-left px-2 border-b-2 border-black">Repo</th>
+          <th className="text-left px-2 border-b-2 border-black">Commits</th>
         </tr>
       </thead>
       <tbody>
         {repos.map((r) => (
-          <tr key={r.name}>
+          <tr key={r.name} className="border-b border-black last:border-b-0">
             <td className="px-2">{r.name}</td>
             <td className="px-2">{r.commits}</td>
           </tr>

--- a/components/UsernameForm.tsx
+++ b/components/UsernameForm.tsx
@@ -29,17 +29,19 @@ export default function UsernameForm() {
     <form onSubmit={onSubmit} className="flex flex-col gap-2" aria-busy="false">
       <div className="flex gap-2">
         <input
-          className={`border p-2 text-black ${error ? "border-red-500" : ""}`}
+          className={`border-2 border-black px-4 py-2 bg-white text-black ${
+            error ? "border-red-600" : ""
+          }`}
           value={value}
           onChange={handleChange}
           aria-label="GitHub username"
           aria-invalid={!!error}
         />
-        <button className="bg-blue-500 text-white px-4" type="submit">
+        <button className="border-2 border-black px-4 py-2 bg-black text-white" type="submit">
           View
         </button>
       </div>
-      {error && <p className="text-red-500 text-sm">{error}</p>}
+      {error && <p className="text-red-600 text-sm">{error}</p>}
     </form>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,19 +2,14 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 body {
-  background: var(--background);
-  color: var(--foreground);
+  background: #fff;
+  color: #000;
+  font-family: monospace;
 }
+
+button,
+input {
+  border-radius: 0;
+}
+


### PR DESCRIPTION
## Summary
- apply brutalist layout with monochrome palette and monospace fonts
- rebuild header, forms, tables, and commit list with thick black borders
- streamline error messages using stark, border-only styling

## Testing
- `pnpm lint`
- `pnpm test` (fails: Cannot find package '@/lib/auth')
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68ab56d4ed9c832e81803ae7ad3a018a